### PR TITLE
Main page layout change to add cancellation policy

### DIFF
--- a/static/jade/he/index.jade
+++ b/static/jade/he/index.jade
@@ -28,33 +28,35 @@ block viewport
     .program
       .program-item-rtl
         h2 רוצה להרצות?
-        p.
+        p.lead.
           מעוניין/נת להעביר הרצאה בכנס Pycon הראשון בישראל?
           #[a(href="http://goo.gl/forms/iEBqCcqFtI") שלח/י הצעת הרצאה]!
         p. 
-          יש שאלות? ניתן לפנות אלינו ישירות בכתובת
+          יש שאלות על הגשת הצעות? ניתן לפנות אלינו ישירות בכתובת
           #[a(href="mailto:cfp@pycon.org.il") cfp@pycon.org.il]
         p. 
           המועד האחרון להגשת הצעות הוא ה-2 באפריל 2016.
 
       .program-item-rtl
-        h2 מיקום
-        //- .date Saturday 14th
+        h2  הרשמה לכנס
+        p.lead.
+          ההרשמה נפתחה! #[a(href="https://ti.to/pycon-israel/pycon-israel-2016 ") כרטיסים ניתן להשיג כאן].
         p.
-          הכנס יתקיים בקניון איילון, במתחם הקולנועים Yes Planet.
-        .venue
-          i.fa.fa-map-marker
-          span.
-            #[a(href="https://goo.gl/maps/qvZwf6Ju3Wq") Yes Planet, קניון איילון, רמת גן]
+          עלות כרטיס היא 250 ₪ עד ל-2 באפריל, לאחר מכן עלות כרטיס תהיה 350 ₪.
+        p.
+          המקום מוגבל, אז קנו כרטיסים עכשיו!
+        p. 
+          יש שאלות? ניתן לפנות אלינו ישירות בכתובת
+          #[a(href="mailto:info@pycon.org.il") info@pycon.org.il]
 
-    .registration
-      h2 הרשמה
-      p.lead.
-        ההרשמה נפתחה! #[a(href="https://ti.to/pycon-israel/pycon-israel-2016 ") כרטיסים ניתן להשיג כאן].
-      p.
-        עלות כרטיס היא 250 ₪ עד ל-2 באפריל, לאחר מכן עלות כרטיס תהיה 350 ₪.
-      p.
-        המקום מוגבל, אז קנו כרטיסים עכשיו!
+    .location
+      h2(align='center') מיקום
+      p(align='center', style='font-size: 24px;').
+        הכנס יתקיים בקניון איילון, במתחם הקולנועים Yes Planet.
+      .venue(align='center', style='font-size: 24px;')
+        i.fa.fa-map-marker
+        span.
+          #[a(href="https://goo.gl/maps/qvZwf6Ju3Wq") Yes Planet, קניון איילון, רמת גן]
 
     .djangogirls
       h2 Django Girls
@@ -108,6 +110,12 @@ block viewport
         .sponsor
           a.sponsor-imper(href="http://www.applitools.com")
             img(src=pageUrl("static/images/sponsors/applitools.png"))
+
+    .cancellation
+      hr(width="75%", align="center")
+      h3(align='center') ביטול רישום לכנס
+      p(align='center').
+        ביטול יבוצע ע"י שליחת דוא"ל לכתובת info@pycon.org.il וקבלת אישור שההרשמה בוטלה. לכרטיסים שיבוטלו עד 8 באפריל יוחזר מלוא הסכום ששולם. כרטיסים שיבוטלו עד 21 באפריל יקבלו החזר של 80% מהתשלום. עקב חג הפסח לא נוכל לקבל ביטולים לאחר 21 באפריל.
 
     .news
       .line

--- a/static/jade/index.jade
+++ b/static/jade/index.jade
@@ -28,37 +28,34 @@ block viewport
   .container
     .program
       .program-item
-        h2 Become a Speaker
+        h2 Registration
+        p.lead.
+          Registration is now open! #[a(href="https://ti.to/pycon-israel/pycon-israel-2016 ") Get your tickets here].
         p.
-          Interested in giving a talk at the first Israeli PyCon?
-          #[a(href="http://goo.gl/forms/iEBqCcqFtI") Submit a talk proposal]!
-        p. 
-          If you have any questions, feel free to contact us directly at 
-          #[a(href="mailto:cfp@pycon.org.il") cfp@pycon.org.il]
-        p. 
-          The deadline for submitting a proposal is April 2nd, 2016.
+          Tickets cost 250 ₪ until April 2nd, after which their price will 
+          increase to 350 ₪.
+        p.
+          If you have any questions, contact us directly at #[a(href="mailto:info@pycon.org.il") info@pycon.org.il]
 
       .program-item
-        h2 Location
-        //- .date Saturday 14th
+        h2 Become a Speaker
+        p.lead.
+          Interested in giving a talk at the first Israeli PyCon?
+          #[a(href="http://goo.gl/forms/iEBqCcqFtI") Submit a talk proposal]!
         p.
-          The conference will take place in the Ayalon Mall, at the Yes Planet 
-          cinema complex.
-        .venue
-          i.fa.fa-map-marker
-          span.
-            #[a(href="https://goo.gl/maps/qvZwf6Ju3Wq") Yes Planet, Ayalon Mall, Ramat Gan]
+          If you have any questions about submissions, contact us directly at 
+          #[a(href="mailto:cfp@pycon.org.il") cfp@pycon.org.il]
+        p.
+          The deadline for submitting a proposal is April 2nd, 2016.
 
-    .registration
-      h2 Registration
-      p.lead.
-        Registration is now open! #[a(href="https://ti.to/pycon-israel/pycon-israel-2016 ") Get your tickets here].
-      p.
-        Tickets cost 250 ₪ until April 2nd, after which their price will 
-        increase to 350 ₪.
-      p.
-        Space is limited, so 
-        #[a(href="https://ti.to/pycon-israel/pycon-israel-2016 ") get your ticket now!]
+    .location
+      h2(align='center') Location
+      p(align='center', style='font-size: 24px;').
+        The conference will take place in the Ayalon Mall, at the Yes Planet cinema complex.
+      .venue(align='center')
+        i.fa.fa-map-marker
+        span.
+          #[a(href="https://goo.gl/maps/qvZwf6Ju3Wq") Yes Planet, Ayalon Mall, Ramat Gan]
 
     .djangogirls
       h2 Django Girls
@@ -117,6 +114,18 @@ block viewport
           a.sponsor-imper(href="https://www.python.org/psf/")
             img(src=pageUrl("static/images/sponsors/psf.png"))
 
+    .cancellation
+      hr(width="75%", align="center")
+      h3(align='center') Cancellation policy
+      p.
+        Registration cancellations must be submitted in writing to info@pycon.org.il. Refund amount is based on the dates your cancellation has been received and acknowledged in the following way:
+      ul#books
+        li.
+          Cancellation received by April 8: 100% refund.
+        li.
+          Cancellation received by April 21: 80% refund.
+      p.
+        Due to local holidays this year we won’t be able process cancellation requests post April 21st, and therefore there will be no refund after this date.
 
     .news
       .line


### PR DESCRIPTION
This update adds a cancellation policy section before the social media
streams. Additionally the subscription part is now next to the CFP to
get the right focus.
