### PR TITLE
Sessions: add missing space

### DIFF
--- a/static/jade/about/speakers.jade
+++ b/static/jade/about/speakers.jade
@@ -8,7 +8,7 @@ mixin talk(workshop)
       = workshop.title
       if workshop.name
         small
-            | by 
+            |  by 
         normal
             = workshop.name
 


### PR DESCRIPTION
This patch adds a missing space before the 'by' word in the title.
